### PR TITLE
Add UnitTestExercise solution with member service

### DIFF
--- a/UnitTestExercise/UnitTestExercise.Repository/FakeMemberRepository.cs
+++ b/UnitTestExercise/UnitTestExercise.Repository/FakeMemberRepository.cs
@@ -1,0 +1,20 @@
+using UnitTestExercise.Repository.Interface;
+
+namespace UnitTestExercise.Repository;
+
+public class FakeMemberRepository : IMemberRepository
+{
+    private readonly Dictionary<string, Member> _members = new();
+
+    public bool Exists(string idNumber) => _members.ContainsKey(idNumber);
+
+    public void AddMember(Member member)
+    {
+        _members[member.IdNumber] = member;
+    }
+
+    public Member? GetMember(string idNumber)
+    {
+        return _members.TryGetValue(idNumber, out var member) ? member : null;
+    }
+}

--- a/UnitTestExercise/UnitTestExercise.Repository/Interface/IMemberRepository.cs
+++ b/UnitTestExercise/UnitTestExercise.Repository/Interface/IMemberRepository.cs
@@ -1,0 +1,8 @@
+namespace UnitTestExercise.Repository.Interface;
+
+public interface IMemberRepository
+{
+    bool Exists(string idNumber);
+    void AddMember(Member member);
+    Member? GetMember(string idNumber);
+}

--- a/UnitTestExercise/UnitTestExercise.Repository/Member.cs
+++ b/UnitTestExercise/UnitTestExercise.Repository/Member.cs
@@ -1,0 +1,8 @@
+namespace UnitTestExercise.Repository;
+
+public class Member
+{
+    public string IdNumber { get; set; } = string.Empty;
+    public string Name { get; set; } = string.Empty;
+    public string PasswordHash { get; set; } = string.Empty;
+}

--- a/UnitTestExercise/UnitTestExercise.Repository/UnitTestExercise.Repository.csproj
+++ b/UnitTestExercise/UnitTestExercise.Repository/UnitTestExercise.Repository.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Folder Include="Interface\" />
+  </ItemGroup>
+
+</Project>

--- a/UnitTestExercise/UnitTestExercise.Service/Interface/IMemberService.cs
+++ b/UnitTestExercise/UnitTestExercise.Service/Interface/IMemberService.cs
@@ -1,0 +1,10 @@
+using UnitTestExercise.Repository;
+
+namespace UnitTestExercise.Service.Interface;
+
+public interface IMemberService
+{
+    bool Register(string idNumber, string password, string name);
+    Member? GetMember(string idNumber);
+    bool VerifyPassword(string idNumber, string password);
+}

--- a/UnitTestExercise/UnitTestExercise.Service/MemberService.cs
+++ b/UnitTestExercise/UnitTestExercise.Service/MemberService.cs
@@ -1,0 +1,41 @@
+using System.Security.Cryptography;
+using System.Text;
+using UnitTestExercise.Repository;
+using UnitTestExercise.Repository.Interface;
+using UnitTestExercise.Service.Interface;
+
+namespace UnitTestExercise.Service;
+
+public class MemberService(IMemberRepository repo) : IMemberService
+{
+    public bool Register(string idNumber, string password, string name)
+    {
+        if (string.IsNullOrWhiteSpace(idNumber) || idNumber.Length != 10)
+            throw new ArgumentException("Id number must be length 10", nameof(idNumber));
+
+        if (repo.Exists(idNumber))
+            return false;
+
+        var hash = Hash(password);
+        var member = new Member { IdNumber = idNumber, Name = name, PasswordHash = hash };
+        repo.AddMember(member);
+        return true;
+    }
+
+    public Member? GetMember(string idNumber) => repo.GetMember(idNumber);
+
+    public bool VerifyPassword(string idNumber, string password)
+    {
+        var member = repo.GetMember(idNumber);
+        if (member == null) return false;
+        var hash = Hash(password);
+        return string.Equals(member.PasswordHash, hash, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string Hash(string text)
+    {
+        var bytes = Encoding.UTF8.GetBytes(text);
+        var hashed = MD5.HashData(bytes);
+        return Convert.ToHexString(hashed);
+    }
+}

--- a/UnitTestExercise/UnitTestExercise.Service/UnitTestExercise.Service.csproj
+++ b/UnitTestExercise/UnitTestExercise.Service/UnitTestExercise.Service.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Folder Include="Interface\" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\UnitTestExercise.Repository\UnitTestExercise.Repository.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/UnitTestExercise/UnitTestExercise.sln
+++ b/UnitTestExercise/UnitTestExercise.sln
@@ -1,0 +1,21 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UnitTestExercise.Service", "UnitTestExercise.Service\UnitTestExercise.Service.csproj", "{F522AF5D-8A0B-454C-91F2-9411E5587770}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UnitTestExercise.Repository", "UnitTestExercise.Repository\UnitTestExercise.Repository.csproj", "{CD078D03-6AED-43EA-90B5-591FBF392996}"
+EndProject
+Global
+    GlobalSection(SolutionConfigurationPlatforms) = preSolution
+        Debug|Any CPU = Debug|Any CPU
+        Release|Any CPU = Release|Any CPU
+    EndGlobalSection
+    GlobalSection(ProjectConfigurationPlatforms) = postSolution
+        {F522AF5D-8A0B-454C-91F2-9411E5587770}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {F522AF5D-8A0B-454C-91F2-9411E5587770}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {F522AF5D-8A0B-454C-91F2-9411E5587770}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {F522AF5D-8A0B-454C-91F2-9411E5587770}.Release|Any CPU.Build.0 = Release|Any CPU
+        {CD078D03-6AED-43EA-90B5-591FBF392996}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {CD078D03-6AED-43EA-90B5-591FBF392996}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {CD078D03-6AED-43EA-90B5-591FBF392996}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {CD078D03-6AED-43EA-90B5-591FBF392996}.Release|Any CPU.Build.0 = Release|Any CPU
+    EndGlobalSection
+EndGlobal


### PR DESCRIPTION
## Summary
- add new `UnitTestExercise` solution with Service and Repository projects
- implement `MemberService` and interfaces for registering and retrieving users
- include fake in-memory repository storing hashed passwords

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845956110488324b69b26dff8d9e836